### PR TITLE
Make GA cookieDomain optional and always anonymize IP

### DIFF
--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -261,20 +261,18 @@
 
 <div id="global-app-error" class="app-error hidden"></div>
 
-{{#showGoogleAnalytics}}
-{{#analyticsHost}}
-{{#token}}
+{{#googleAnalytics}}
+{{#trackingId}}
 <script type="text/javascript">
 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
             (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-ga('create', '{{token}}', '{{{analyticsHost}}}');
-ga('send', 'pageview', { 'anonymizeIp': {{#analyticsAnonymizeIp}}true{{/analyticsAnonymizeIp}}{{^analyticsAnonymizeIp}}false{{/analyticsAnonymizeIp}} });
+ga('create', '{{trackingId}}', '{{#cookieDomain}}{{cookieDomain}}{{/cookieDomain}}{{^cookieDomain}}auto{{/cookieDomain}}');
+ga('send', 'pageview', { 'anonymizeIp': true });
 </script>
-{{/token}}
-{{/analyticsHost}}
-{{/showGoogleAnalytics}}
+{{/trackingId}}
+{{/googleAnalytics}}
 
 {{#ssoUrl}}
     <script type="text/javascript">var ssoUrl = "{{ssoUrl}}";</script>

--- a/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
@@ -100,6 +100,31 @@ class FooterSpec extends WordSpec with Matchers  with Results with WithFakeAppli
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map()).body
       renderedHtml should not include(s"""<script type="text/javascript">var ssoUrl = """)
     }
+
+    "not show Google Analytics snippet when no googleAnalytics given SDT-475" in new Setup {
+      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map()).body
+      renderedHtml should not include(s"""(window,document,'script','//www.google-analytics.com/analytics.js','ga')""")
+    }
+
+    "show Google Analytics snippet when googleAnalytics trackingId given SDT-475" in new Setup {
+      val id = "UA-XXXX-Y"
+      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
+        "googleAnalytics" -> Map("trackingId" -> id)
+      )).body
+      renderedHtml should include(s"""ga('create', '$id', 'auto');""")
+    }
+
+    "support custom cookie domain for Google Analytics snippet SDT-475" in new Setup {
+      val id = "UA-XXXX-Y"
+      val host = "example.com"
+      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
+        "googleAnalytics" -> Map(
+          "trackingId" -> id,
+          "cookieDomain" -> host
+        )
+      )).body
+      renderedHtml should include(s"""ga('create', '$id', '$host');""")
+    }
   }
 
   trait Setup {


### PR DESCRIPTION
If a `googleAnalytics` Map consisting of at least a `trackingId` value is passed to `templateArgs` then the Google Analytics snippet will be rendered with a cookie domain of `auto`:

```
localTemplateRenderer.parseTemplate(Html(""), Map(
  "googleAnalytics" -> Map(
    "trackingId" -> "UA-XXXX-Y"
  )
))
```

If an optional `cookieDomain` value is also passed then the cookie domain is set to to that value instead.

```
localTemplateRenderer.parseTemplate(Html(""), Map(
  "googleAnalytics" -> Map(
    "trackingId" -> "UA-XXXX-Y",
    "cookieDomain" -> ".example.com"
  )
))
```