### PR TITLE
Sdt 622

### DIFF
--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -119,9 +119,7 @@
                     <img src="@prependGovUkTemplateUrl("images/gov.uk_logotype_crown.png")" alt=""> GOV.UK
                 </a>
             </div>
-
         </div>
-
         <div class="header-proposition">
             <div class="content">
                 {{#hasNavLinks}}
@@ -155,7 +153,6 @@
                 </nav>
             </div>
         </div>
-
     </div>
 </header>
 <!--end header-->
@@ -183,16 +180,14 @@
                 </p>
             </div>
             {{/betaBanner}}
-
             {{^removeServiceInfo}}
             {{#includeHMRCBranding}}
             <div class="logo">
                 <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>
             </div>
-           {{/includeHMRCBranding}}
-           {{#showLastLogInStatus}}
-            <div id="lastlogin" class="service-info__help">
-                <p>
+            {{/includeHMRCBranding}}
+            {{#showLastLogInStatus}}
+            <div class="last-login">
                     {{#userDisplayName}}
                     {{^previouslyLoggedInAt}}
                     {{{userDisplayName}}}, this is the first time you have logged in.

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -164,6 +164,7 @@
 
 <main id="wrapper" role="main" {{#mainClass}}class="{{mainClass}}"{{/mainClass}} {{{mainAttributes}}}>
   <div id="content">
+        {{^removeServiceInfo}}
         <div class="service-info">
             {{#betaBanner}}
             <div class="beta-banner">
@@ -180,7 +181,6 @@
                 </p>
             </div>
             {{/betaBanner}}
-            {{^removeServiceInfo}}
             {{#includeHMRCBranding}}
             <div class="logo">
                 <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -185,49 +185,42 @@
             {{/betaBanner}}
 
             {{^removeServiceInfo}}
-            <div class="centered-content">
-                <div class="service-info {{#includeGridWrapper}}grid-wrapper{{/includeGridWrapper}}">
-                    {{#includeHMRCBranding}}
-                    <div class="logo">
-                        <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>
-                    </div>
-                    {{/includeHMRCBranding}}
-                    {{#showLastLogInStatus}}
-                    <div id="lastlogin" class="service-info__help">
-                        <p>
-                            {{#userDisplayName}}
-                            {{^previouslyLoggedInAt}}
-                            {{{userDisplayName}}}, this is the first time you have logged in.
-                            {{/previouslyLoggedInAt}}
-                            {{#previouslyLoggedInAt}}
-                            {{{userDisplayName}}}, you last signed in {{{previouslyLoggedInAt}}}.
-                            {{/previouslyLoggedInAt}}
-                            {{/userDisplayName}}
-                            {{#logoutUrl}}
-                            <br><a id="logOutStatusHref" href="{{logoutUrl}}">Sign out</a>
-                            {{/logoutUrl}}
-                        </p>
-                    </div>
-                    {{/showLastLogInStatus}}
-                </div>
+            {{#includeHMRCBranding}}
+            <div class="logo">
+                <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>
             </div>
-            {{/removeServiceInfo}}
-
-
-            <div id="content">
-
-                {{{ actingAttorneyBanner }}}
-
-                {{{ mainContentHeader }}}
-
-                {{{ article }}}
-
-                {{{ sidebar }}}
-
-                {{{ getHelpForm }}}
-
+           {{/includeHMRCBranding}}
+           {{#showLastLogInStatus}}
+            <div id="lastlogin" class="service-info__help">
+                <p>
+                    {{#userDisplayName}}
+                    {{^previouslyLoggedInAt}}
+                    {{{userDisplayName}}}, this is the first time you have logged in.
+                    {{/previouslyLoggedInAt}}
+                    {{#previouslyLoggedInAt}}
+                    {{{userDisplayName}}}, you last signed in {{{previouslyLoggedInAt}}}.
+                    {{/previouslyLoggedInAt}}
+                    {{/userDisplayName}}
+                    {{#logoutUrl}}
+                    <br><a id="logOutStatusHref" href="{{logoutUrl}}">Sign out</a>
+                    {{/logoutUrl}}
+                </p>
             </div>
+            {{/showLastLogInStatus}}
         </div>
+
+        {{/removeServiceInfo}}
+
+        {{{ actingAttorneyBanner }}}
+
+        {{{ mainContentHeader }}}
+
+        {{{ article }}}
+
+        {{{ sidebar }}}
+
+        {{{ getHelpForm }}}
+
     </div>
 </main>
 

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -111,7 +111,7 @@
 </div>
 
 
-<header role="banner" id="global-header" class="{{#nav}}with-proposition{{/nav}}">
+<header role="banner" id="global-header" class="with-proposition">
     <div class="header-wrapper">
         <div class="header-global">
             <div class="header-logo">

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -166,65 +166,68 @@
 </div>
 
 <main id="wrapper" role="main" {{#mainClass}}class="{{mainClass}}"{{/mainClass}} {{{mainAttributes}}}>
-
-    {{#betaBanner}}
-    <div class="beta-banner">
-        <p>
-            <strong class="phase-tag">BETA</strong>
-            <span>This is a new service{{^feedbackIdentifier}}.{{/feedbackIdentifier}}
-                {{#feedbackIdentifier}}
-                   - your <a id="feedback-link"
-                   href="beta-feedback-unauthenticated?service={{feedbackIdentifier}}"
-                   data-sso="false"
-                   data-journey-click="other-global:Click:Feedback">feedback</a> will help us to improve it.
-                {{/feedbackIdentifier}}
-            </span>
-        </p>
-    </div>
-    {{/betaBanner}}
-
-    {{^removeServiceInfo}}
-    <div class="centered-content">
-        <div class="service-info {{#includeGridWrapper}}grid-wrapper{{/includeGridWrapper}}">
-            {{#includeHMRCBranding}}
-            <div class="logo">
-                <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>
-            </div>
-            {{/includeHMRCBranding}}
-            {{#showLastLogInStatus}}
-            <div id="lastlogin" class="service-info__help">
+  <div id="content">
+        <div class="service-info">
+            {{#betaBanner}}
+            <div class="beta-banner">
                 <p>
-                    {{#userDisplayName}}
-                    {{^previouslyLoggedInAt}}
-                    {{{userDisplayName}}}, this is the first time you have logged in.
-                    {{/previouslyLoggedInAt}}
-                    {{#previouslyLoggedInAt}}
-                    {{{userDisplayName}}}, you last signed in {{{previouslyLoggedInAt}}}.
-                    {{/previouslyLoggedInAt}}
-                    {{/userDisplayName}}
-                    {{#logoutUrl}}
-                    <br><a id="logOutStatusHref" href="{{logoutUrl}}">Sign out</a>
-                    {{/logoutUrl}}
+                    <strong class="phase-tag">BETA</strong>
+                    <span>This is a new service{{^feedbackIdentifier}}.{{/feedbackIdentifier}}
+                        {{#feedbackIdentifier}}
+                           - your <a id="feedback-link"
+                           href="beta-feedback-unauthenticated?service={{feedbackIdentifier}}"
+                           data-sso="false"
+                           data-journey-click="other-global:Click:Feedback">feedback</a> will help us to improve it.
+                        {{/feedbackIdentifier}}
+                    </span>
                 </p>
             </div>
-            {{/showLastLogInStatus}}
+            {{/betaBanner}}
+
+            {{^removeServiceInfo}}
+            <div class="centered-content">
+                <div class="service-info {{#includeGridWrapper}}grid-wrapper{{/includeGridWrapper}}">
+                    {{#includeHMRCBranding}}
+                    <div class="logo">
+                        <span class="organisation-logo organisation-logo-medium">HM Revenue &amp; Customs</span>
+                    </div>
+                    {{/includeHMRCBranding}}
+                    {{#showLastLogInStatus}}
+                    <div id="lastlogin" class="service-info__help">
+                        <p>
+                            {{#userDisplayName}}
+                            {{^previouslyLoggedInAt}}
+                            {{{userDisplayName}}}, this is the first time you have logged in.
+                            {{/previouslyLoggedInAt}}
+                            {{#previouslyLoggedInAt}}
+                            {{{userDisplayName}}}, you last signed in {{{previouslyLoggedInAt}}}.
+                            {{/previouslyLoggedInAt}}
+                            {{/userDisplayName}}
+                            {{#logoutUrl}}
+                            <br><a id="logOutStatusHref" href="{{logoutUrl}}">Sign out</a>
+                            {{/logoutUrl}}
+                        </p>
+                    </div>
+                    {{/showLastLogInStatus}}
+                </div>
+            </div>
+            {{/removeServiceInfo}}
+
+
+            <div id="content">
+
+                {{{ actingAttorneyBanner }}}
+
+                {{{ mainContentHeader }}}
+
+                {{{ article }}}
+
+                {{{ sidebar }}}
+
+                {{{ getHelpForm }}}
+
+            </div>
         </div>
-    </div>
-    {{/removeServiceInfo}}
-
-
-    <div id="content">
-
-        {{{ actingAttorneyBanner }}}
-
-        {{{ mainContentHeader }}}
-
-        {{{ article }}}
-
-        {{{ sidebar }}}
-
-        {{{ getHelpForm }}}
-
     </div>
 </main>
 

--- a/test/uk/gov/hmrc/frontendtemplateprovider/MainSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/MainSpec.scala
@@ -84,18 +84,6 @@ class MainSpec extends WordSpec with Matchers  with Results with WithFakeApplica
       renderedHtml should include("This is a new service.")
     }
 
-    "includeGridWrapper should be included in service-info if specified SDT-482" in new Setup {
-      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
-        "includeGridWrapper" -> true
-      )).body
-      renderedHtml should include("""<div class="service-info grid-wrapper">""")
-    }
-
-    "includeGridWrapper should not be included in service-info if not set SDT-482" in new Setup {
-      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map()).body
-      renderedHtml should include("""<div class="service-info ">""") // extra space because of mustache
-    }
-
     "hmrc branding included if set SDT-482" in new Setup {
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
         "includeHMRCBranding" -> true


### PR DESCRIPTION
Using pertax frontend as a reference the markup has now been updated and beta banner is now back in the content container. When checking the layout with nav turned on, HMRC logo showing and logged in status in place I did notice that the logged in status message could use additional styling to position correctly. If you look at pertax frontend you will see they add there own styles to accomplish this (see screenshot)
![screen shot 2017-07-14 at 15 37 15](https://user-images.githubusercontent.com/10154302/28217780-37223c6a-68ae-11e7-8a10-2a3a7acd4ef4.png)
.