### PR TITLE
Sdt 625 assets version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A mustache template provider that gives you a govuk template. It allows for vari
 
 To add this to your service, place this inside your routes for `Dev` and `Prod` in application.conf:
 
-```json <!--even though this isn't json, just gives it a nicer colour-->
+```json &lt;!--even though this isn&#39;t json, just gives it a nicer colour--&gt;
 frontend-template-provider {
  host = localhost
  port = 9310
@@ -26,6 +26,18 @@ If you only want to populate the main content of the page and wish to use sensib
 ```scala
 val article = Html("<p>hello world!</p>")
 localTemplateRenderer.parseTemplate(article, Map())
+```
+
+*Specifying a version of assets-fronted*
+
+The version of assets-frontend defaults to the version set by the template. This will almost always be kept as the latest. **Warning:** This could break your frontend on page reload if a version of assets-fronted is released with a breaking change that changes or removes styles for some markup you were relying on.
+
+In order to avoid this issue, frontends can specify which version of assets-frontend they rely on by passing through a path to which version of assets-frontend you require:
+
+```scala
+localTemplateRenderer.parseTemplate(article, Map(
+  "assetsPath" -> assetsPath
+))
 ```
 
 *Adding extra html around the article*
@@ -163,9 +175,9 @@ The options of what you can populate are as follows:
 - You can allow `grid-wrapper` to be one of the classes of the `service-info` by having `includeGridWrapper -> true` as an option in the `templateArgs`. By default it's not set.
 - You can include the HMRC branding by setting `includeHMRCBranding` to true in the `templateArgs`.
 - You can show last login status.
-	- You can set the `userDisplayName`, `previouslyLoggedInAt` and `logoutUrl` 
-	- If you do not provide `previouslyLoggedInAt` and the `userDisplayName` is `Dave`, `Dave, this is the first time you have logged in.` would be displayed.
-	- If you provided a `previouslyLoggedInAt` (say `01 Jan 2017`), you would get `Dave, you last signed in 01 Jan 2017.
+ - You can set the `userDisplayName`, `previouslyLoggedInAt` and `logoutUrl` 
+ - If you do not provide `previouslyLoggedInAt` and the `userDisplayName` is `Dave`, `Dave, this is the first time you have logged in.` would be displayed.
+ - If you provided a `previouslyLoggedInAt` (say `01 Jan 2017`), you would get `Dave, you last signed in 01 Jan 2017.
 
 Example of a fully populated service-info:
 
@@ -269,7 +281,7 @@ localTemplateRenderer.parseTemplate(Html(""), Map(
 		Map("url" -> "url2.com", "text" -> "second link title")
 	)
 ))
-```      
+```
 
 would produce:
 

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -78,13 +78,28 @@
 
     <!-- head -->
     <!--[if lt IE 8 ]>
+    {{#assetsVersion}}
+    <link rel='stylesheet' href='/assets/{{ assetsVersion }}/stylesheets/application-ie7.min.css' />
+    {{/assetsVersion}}
+    {{^assetsVersion}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application-ie7.min.css' />
+    {{/assetsVersion}}
     <![endif]-->
     <!--[if IE 8 ]>
+    {{#assetsVersion}}
+    <link rel='stylesheet' href='/assets/{{#assetsVersion}}/stylesheets/application-ie.min.css' />
+    {{/assetsVersion}}
+    {{^assetsVersion}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application-ie.min.css' />
+    {{/assetsVersion}}
     <![endif]-->
     <!--[if gt IE 8]><!-->
+    {{#assetsVersion}}
+    <link rel='stylesheet' href='/assets/{{ assetsVersion }}/stylesheets/application.min.css' />
+    {{/assetsVersion}}
+    {{^assetsVersion}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application.min.css' />
+    {{/assetsVersion}}
     <!--<![endif]-->
 
 
@@ -224,8 +239,6 @@
     <div class="footer-wrapper">
         {{{ footerTop }}}
 
-        <script src="@{assetsPath}javascripts/application.min.js" type="text/javascript"></script>
-
         <div class="footer-meta">
             <div class="footer-meta-inner">
                 <ul class="platform-help-links">
@@ -284,6 +297,14 @@
 {{#ssoUrl}}
     <script type="text/javascript">var ssoUrl = "{{ssoUrl}}";</script>
 {{/ssoUrl}}
+
+{{#assetsVersion}}
+<script src="/assets/{{ assetsVersion }}/javascripts/application.min.js" type="text/javascript"></script>
+{{/assetsVersion}}
+{{^assetsVersion}}
+<script src="@{assetsPath}javascripts/application.min.js" type="text/javascript"></script>
+{{/assetsVersion}}
+
 <!--<script src="@prependGovUkTemplateUrl("javascripts/govuk-template.js")" type="text/javascript"></script>-->
 {{#scriptElems}}
     {{#url}}

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -78,28 +78,28 @@
 
     <!-- head -->
     <!--[if lt IE 8 ]>
-    {{#assetsVersion}}
+    {{#assetsPath}}
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie7.min.css' />
-    {{/assetsVersion}}
-    {{^assetsVersion}}
+    {{/assetsPath}}
+    {{^assetsPath}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application-ie7.min.css' />
-    {{/assetsVersion}}
+    {{/assetsPath}}
     <![endif]-->
     <!--[if IE 8 ]>
-    {{#assetsVersion}}
-    <link rel='stylesheet' href='/assets/{{#assetsVersion}}/stylesheets/application-ie.min.css' />
-    {{/assetsVersion}}
-    {{^assetsVersion}}
+    {{#assetsPath}}
+    <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie.min.css' />
+    {{/assetsPath}}
+    {{^assetsPath}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application-ie.min.css' />
-    {{/assetsVersion}}
+    {{/assetsPath}}
     <![endif]-->
     <!--[if gt IE 8]><!-->
-    {{#assetsVersion}}
+    {{#assetsPath}}
     <link rel='stylesheet' href='{{assetsPath}}stylesheets/application.min.css' />
-    {{/assetsVersion}}
-    {{^assetsVersion}}
+    {{/assetsPath}}
+    {{^assetsPath}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application.min.css' />
-    {{/assetsVersion}}
+    {{/assetsPath}}
     <!--<![endif]-->
 
 
@@ -298,12 +298,12 @@
     <script type="text/javascript">var ssoUrl = "{{ssoUrl}}";</script>
 {{/ssoUrl}}
 
-{{#assetsVersion}}
+{{#assetsPath}}
 <script src="{{assetsPath}}javascripts/application.min.js" type="text/javascript"></script>
-{{/assetsVersion}}
-{{^assetsVersion}}
+{{/assetsPath}}
+{{^assetsPath}}
 <script src="@{assetsPath}javascripts/application.min.js" type="text/javascript"></script>
-{{/assetsVersion}}
+{{/assetsPath}}
 
 <!--<script src="@prependGovUkTemplateUrl("javascripts/govuk-template.js")" type="text/javascript"></script>-->
 {{#scriptElems}}

--- a/app/views/Application/gov_main_mustache.scala.txt
+++ b/app/views/Application/gov_main_mustache.scala.txt
@@ -79,7 +79,7 @@
     <!-- head -->
     <!--[if lt IE 8 ]>
     {{#assetsVersion}}
-    <link rel='stylesheet' href='/assets/{{ assetsVersion }}/stylesheets/application-ie7.min.css' />
+    <link rel='stylesheet' href='{{assetsPath}}stylesheets/application-ie7.min.css' />
     {{/assetsVersion}}
     {{^assetsVersion}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application-ie7.min.css' />
@@ -95,7 +95,7 @@
     <![endif]-->
     <!--[if gt IE 8]><!-->
     {{#assetsVersion}}
-    <link rel='stylesheet' href='/assets/{{ assetsVersion }}/stylesheets/application.min.css' />
+    <link rel='stylesheet' href='{{assetsPath}}stylesheets/application.min.css' />
     {{/assetsVersion}}
     {{^assetsVersion}}
     <link rel='stylesheet' href='@{assetsPath}stylesheets/application.min.css' />
@@ -299,7 +299,7 @@
 {{/ssoUrl}}
 
 {{#assetsVersion}}
-<script src="/assets/{{ assetsVersion }}/javascripts/application.min.js" type="text/javascript"></script>
+<script src="{{assetsPath}}javascripts/application.min.js" type="text/javascript"></script>
 {{/assetsVersion}}
 {{^assetsVersion}}
 <script src="@{assetsPath}javascripts/application.min.js" type="text/javascript"></script>

--- a/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
@@ -44,6 +44,18 @@ class FooterSpec extends WordSpec with Matchers  with Results with WithFakeAppli
   val fakeRequest = FakeRequest("GET", "/")
 
   "Footer" should {
+    "contain links to assets-frontend JS" in new Setup {
+      bodyText should include("<script src=\"www.example.com/1/javascripts/application.min.js\" type=\"text/javascript\"></script>")
+    }
+
+    "contain links to a specified version of assets-frontend CSS" in new Setup {
+      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
+        "assetsPath" -> "www.example.com/2/"
+      )).body
+
+      renderedHtml should include("<script src=\"www.example.com/2/javascripts/application.min.js\" type=\"text/javascript\"></script>")
+    }
+
     "allow additional footer links to be specified SDT 477" in new Setup {
       val href = "www.example.com"
       val text = "something"

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -51,10 +51,20 @@ class HeadSpec extends WordSpec with Matchers with Results with GuiceOneAppPerSu
       bodyText should include("<!--[if gt IE 8]><!--><link href=\"http://localhost:9310/template/assets/stylesheets/govuk-template.css\" media=\"screen\" rel=\"stylesheet\" type=\"text/css\" /><!--<![endif]-->")
     }
 
-    "contain link to assets-frontend application links" in new Setup {
+    "contain links to assets-frontend CSS" in new Setup {
       bodyText should include("<link rel='stylesheet' href='www.example.com/1/stylesheets/application-ie7.min.css' />")
       bodyText should include("<link rel='stylesheet' href='www.example.com/1/stylesheets/application-ie.min.css' />")
       bodyText should include("<link rel='stylesheet' href='www.example.com/1/stylesheets/application.min.css' />")
+    }
+
+    "contain links to a specified version of assets-frontend CSS" in new Setup {
+      val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
+        "assetsPath" -> "www.example.com/2/"
+      )).body
+
+      renderedHtml should include("<link rel='stylesheet' href='www.example.com/2/stylesheets/application-ie7.min.css' />")
+      renderedHtml should include("<link rel='stylesheet' href='www.example.com/2/stylesheets/application-ie.min.css' />")
+      renderedHtml should include("<link rel='stylesheet' href='www.example.com/2/stylesheets/application.min.css' />")
     }
 
     "contain a body opening tag that does not contain a class SDT-470" in new Setup {


### PR DESCRIPTION
The assets version was being set by the template provider. This could potentially break frontends on page reload if the version was bumped with some styles changed o removed without the markup being updated.

Allowing the frontend to pass through the assets version it needs will safeguard against a breaking change at runtime and give the team time to update the markup and release before bumping to the latest version of assets-frontend.