### PR TITLE
SDT-632 Serve the template with a text/html content type header

### DIFF
--- a/app/uk/gov/hmrc/frontendtemplateprovider/GovUkTemplateRendererController.scala
+++ b/app/uk/gov/hmrc/frontendtemplateprovider/GovUkTemplateRendererController.scala
@@ -33,7 +33,7 @@ trait GovUkTemplateRendererController extends BaseController with ServicesConfig
 		val templateLocation = Play.current.configuration.getString("template.url").getOrElse("")
 		val resolveUrl: (String) => String = a => s"${templateLocation}assets/$a"
 
-		Future.successful(Ok(views.txt.Application.gov_main_mustache(resolveUrl, assetsPrefix + "/")))
+		Future.successful(Ok(views.html.Application.gov_main_mustache(resolveUrl, assetsPrefix + "/")))
 	}
 
 }

--- a/app/views/Application/gov_main_mustache.scala.html
+++ b/app/views/Application/gov_main_mustache.scala.html
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *@
+
 @(prependGovUkTemplateUrl: (String) => String, assetsPath: String)
 <!DOCTYPE html>
 <!--[if lt IE 9]><html class="no-js lte-ie8" lang="en"><![endif]-->

--- a/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
@@ -18,16 +18,17 @@ package uk.gov.hmrc.frontendtemplateprovider
 
 import akka.actor.{ActorSystem, Cancellable}
 import org.scalatest.{Matchers, WordSpec}
-import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.mvc.{Result, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
+import play.api.{Application, Configuration}
 import play.twirl.api.Html
 import uk.gov.hmrc.frontendtemplateprovider.controllers.GovUkTemplateRendererController
+import uk.gov.hmrc.play.config.AssetsConfig
 import uk.gov.hmrc.play.http.HeaderCarrier
 import uk.gov.hmrc.play.http.ws.WSGet
-import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+import uk.gov.hmrc.play.test.WithFakeApplication
 import uk.gov.hmrc.renderer.MustacheRendererTrait
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,17 +37,15 @@ class FooterSpec extends WordSpec with Matchers  with Results with WithFakeAppli
 
   implicit val hc = HeaderCarrier()
 
-  override lazy val fakeApplication: Application = new GuiceApplicationBuilder()
-    .configure(Map("assets.url" -> "www.example.com/"))
-    .bindings(bindModules:_*)
-    .build()
-
   val fakeRequest = FakeRequest("GET", "/")
 
-  // ToDo: Fix the hardcoded assets version in this test
+  override lazy val fakeApplication: Application = new GuiceApplicationBuilder()
+    .configure(Map("assets.url" -> "www.example.com/", "assets.version" -> "1"))
+    .build()
+
   "Footer" should {
     "contain links to assets-frontend JS" in new Setup {
-      bodyText should include("<script src=\"www.example.com/2.246.0/javascripts/application.min.js\" type=\"text/javascript\"></script>")
+      bodyText should include("<script src=\"www.example.com/1/javascripts/application.min.js\" type=\"text/javascript\"></script>")
     }
 
     "contain links to a specified version of assets-frontend CSS" in new Setup {
@@ -195,11 +194,14 @@ class FooterSpec extends WordSpec with Matchers  with Results with WithFakeAppli
 
   trait Setup {
 
-    val result: Future[Result] = GovUkTemplateRendererController.serveMustacheTemplate()(fakeRequest)
-    val bodyText: String = contentAsString(result)
-    status(result) shouldBe OK
+    lazy val result: Future[Result] = new GovUkTemplateRendererController{
+      override val assetsPrefix: String = new AssetsConfig {}.assetsPrefix // this is to avoid race condition
+    }.serveMustacheTemplate()(fakeRequest)
+    lazy val bodyText: String = contentAsString(result)
 
-    val localTemplateRenderer = new MustacheRendererTrait {
+    lazy val localTemplateRenderer = new MustacheRendererTrait {
+      status(result) shouldBe OK
+
       override lazy val templateServiceAddress: String = ???
       override lazy val connection: WSGet = ???
       override def scheduleGrabbingTemplate()(implicit ec: ExecutionContext): Cancellable = ???

--- a/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
@@ -43,9 +43,10 @@ class FooterSpec extends WordSpec with Matchers  with Results with WithFakeAppli
 
   val fakeRequest = FakeRequest("GET", "/")
 
+  // ToDo: Fix the hardcoded assets version in this test
   "Footer" should {
     "contain links to assets-frontend JS" in new Setup {
-      bodyText should include("<script src=\"www.example.com/1/javascripts/application.min.js\" type=\"text/javascript\"></script>")
+      bodyText should include("<script src=\"www.example.com/2.246.0/javascripts/application.min.js\" type=\"text/javascript\"></script>")
     }
 
     "contain links to a specified version of assets-frontend CSS" in new Setup {

--- a/test/uk/gov/hmrc/frontendtemplateprovider/GovUkTemplateRendererControllerControllerSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/GovUkTemplateRendererControllerControllerSpec.scala
@@ -34,9 +34,23 @@ class GovUkTemplateRendererControllerControllerSpec extends WordSpec with Matche
     "return 200 with the template rendered correctly" in {
       val result = GovUkTemplateRendererController.serveMustacheTemplate()(fakeRequest)
       val bodyText = contentAsString(result)
+
       status(result) shouldBe OK
+
       bodyText should not contain "@resolveUrl"
       bodyText should include("html")
+
     }
   }
+
+  "GET /serve-template" should {
+    "Serve the template with a \"text/html\" Content-type header" in {
+      val result = GovUkTemplateRendererController.serveMustacheTemplate()(fakeRequest)
+      val mimetype = contentType(result).mkString
+      mimetype should include("text/html")
+
+    }
+
+  }
+
 }

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -225,16 +225,14 @@ class HeadSpec extends WordSpec with Matchers with Results with GuiceOneAppPerSu
   }
 
   trait Setup {
-
-    fakeApplication.configuration ++  Configuration("assets.url" -> "www.example.com/", "assets.version" -> "1")
-
     lazy val result: Future[Result] = new GovUkTemplateRendererController{
       override val assetsPrefix: String = new AssetsConfig {}.assetsPrefix // this is to avoid race condition
     }.serveMustacheTemplate()(fakeRequest)
     lazy val bodyText: String = contentAsString(result)
-    status(result) shouldBe OK
 
     lazy val localTemplateRenderer = new MustacheRendererTrait {
+      status(result) shouldBe OK
+
       override lazy val templateServiceAddress: String = ???
       override lazy val connection: WSGet = ???
       override def scheduleGrabbingTemplate()(implicit ec: ExecutionContext): Cancellable = ???


### PR DESCRIPTION
When the template is served from S3 we're expecting it to have a text/html mime type so modified the service to do the same.

Also fixed a failing test that hard a hard-coded value which will change each time we bump the assets version, this should be done in a better way, (by reading the config?) in future.