### PR TITLE
SDT-638 fix modernizer.js script tag & SDT-639 bump AF version

### DIFF
--- a/app/views/Application/gov_main_mustache.scala.html
+++ b/app/views/Application/gov_main_mustache.scala.html
@@ -113,8 +113,12 @@
     {{#optimizelyProjectId}}
     <script src='{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js' type='text/javascript'></script>
     {{/optimizelyProjectId}}
+    {{#assetsPath}}
+    <script src='{{assetsPath}}javascripts/vendor/modernizr.js' type='text/javascript'></script>
+    {{/assetsPath}}
+    {{^assetsPath}}
     <script src='@{assetsPath}javascripts/vendor/modernizr.js' type='text/javascript'></script>
-
+    {{/assetsPath}}
 </head>
 
 <body>
@@ -257,7 +261,14 @@
                 </ul>
 
                 <div class="open-government-licence">
-                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank"><img src="@{assetsPath}images/open-government-licence_2x.png" alt="Open Government Licence"></a></h2>
+                    <h2><a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">
+                        {{#assetsPath}}
+                        <img src="{{assetsPath}}images/open-government-licence_2x.png" alt="Open Government Licence">
+                        {{/assetsPath}}
+                        {{^assetsPath}}
+                        <img src=@{assetsPath}images/open-government-licence_2x.png" alt="Open Government Licence">
+                        {{/assetsPath}}
+                    </h2>
                     <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3" target="_blank">Open Government Licence v3.0</a>, except where otherwise stated</p>
                 </div>
             </div>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -139,7 +139,7 @@ metrics {
 
 
 assets {
-    version = "2.246.0"
+    version = "2.247.0"
     version = ${?ASSETS_FRONTEND_VERSION}
     url = "http://localhost:9032/assets/"
     minified = true

--- a/test/uk/gov/hmrc/frontendtemplateprovider/GovUkTemplateRendererControllerControllerSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/GovUkTemplateRendererControllerControllerSpec.scala
@@ -23,34 +23,33 @@ import play.api.test.Helpers._
 import uk.gov.hmrc.frontendtemplateprovider.controllers.GovUkTemplateRendererController
 import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
 
-
-class GovUkTemplateRendererControllerControllerSpec extends WordSpec with Matchers  with WithFakeApplication with Results   {
-
+class GovUkTemplateRendererControllerControllerSpec extends WordSpec with Matchers  with WithFakeApplication with Results {
 
   val fakeRequest = FakeRequest("GET", "/")
 
 
   "GET /serve-template" should {
-    "return 200 with the template rendered correctly" in {
+    "Return with an HTTP 200 status" in {
+      val result = GovUkTemplateRendererController.serveMustacheTemplate()(fakeRequest)
+
+      status(result) shouldBe OK
+    }
+
+    "Render the template correctly" in {
       val result = GovUkTemplateRendererController.serveMustacheTemplate()(fakeRequest)
       val bodyText = contentAsString(result)
 
-      status(result) shouldBe OK
-
       bodyText should not contain "@resolveUrl"
       bodyText should include("html")
-
     }
-  }
 
-  "GET /serve-template" should {
     "Serve the template with a \"text/html\" Content-type header" in {
       val result = GovUkTemplateRendererController.serveMustacheTemplate()(fakeRequest)
       val mimetype = contentType(result).mkString
-      mimetype should include("text/html")
 
+      mimetype should include("text/html")
     }
 
   }
-
 }
+


### PR DESCRIPTION
Updated to keep inline with the templates in https://github.com/hmrc/govuk-template which is where the live templates are from.

# Changes
SD-638 fix modernizer.js script tag so that it can be overidden along with the other assets-frontend tags
SDT-639 Bump assets-frontend version to 2.247.0