### PR TITLE
Refinements to the last login details banner

### DIFF
--- a/app/views/Application/gov_main_mustache.scala.html
+++ b/app/views/Application/gov_main_mustache.scala.html
@@ -42,6 +42,26 @@
 
     <link href="@prependGovUkTemplateUrl("stylesheets/govuk-template-print.css")" media="print" rel="stylesheet" type="text/css" />
 
+    <style media="screen" type="text/css">
+
+        div.service-info {
+            border-bottom: 1px solid #dee0e2;
+        }
+        .service-info div.last-login {
+            float: right;
+            color: #6f777b;
+        }
+
+    </style>
+
+    <style media="screen and (min-width: 641px)" type="text/css">
+
+        .service-info div.last-login {
+            margin-top: 0.9em;
+        }
+
+    </style>
+
     <!--[if IE 8]>
     <script type="text/javascript">
         (function(){if(window.opera){return;}
@@ -215,15 +235,15 @@
             {{/includeHMRCBranding}}
             {{#showLastLogInStatus}}
             <div class="last-login">
-                <p>
-                    {{#userDisplayName}}
+                <p class="last-login__more-details text--right font-xsmall">
+
                     {{^previouslyLoggedInAt}}
-                    {{{userDisplayName}}}, this is the first time you have logged in.
+                    This is the first time you have logged in
                     {{/previouslyLoggedInAt}}
                     {{#previouslyLoggedInAt}}
-                    {{{userDisplayName}}}, you last signed in {{{previouslyLoggedInAt}}}.
+                    You last signed in {{{previouslyLoggedInAt}}}
                     {{/previouslyLoggedInAt}}
-                    {{/userDisplayName}}
+
                     {{#logoutUrl}}
                     <br><a id="logOutStatusHref" href="{{logoutUrl}}">Sign out</a>
                     {{/logoutUrl}}

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -225,13 +225,13 @@ class HeadSpec extends WordSpec with Matchers with Results with GuiceOneAppPerSu
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
         "removeServiceInfo" -> true
       )).body
-      renderedHtml should not include(s"""service-info""")
+      renderedHtml should not include(s"""<div class="service-info">""")
     }
 
     "service-info included by default" in new Setup {
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
       )).body
-      renderedHtml should include(s"""service-info""")
+      renderedHtml should include(s"""<div class="service-info">""")
     }
   }
 

--- a/test/uk/gov/hmrc/frontendtemplateprovider/MainSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/MainSpec.scala
@@ -100,34 +100,32 @@ class MainSpec extends WordSpec with Matchers  with Results with WithFakeApplica
 
     "Do not show login information if userDisplayName is not set SDT-481" in new Setup {
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map()).body
-      renderedHtml should not include("this is the first time you have logged in")
+      renderedHtml should not include("This is the first time you have logged in")
       renderedHtml should not include("you last signed in")
       renderedHtml should not include("Sign out")
     }
 
-    "Show 'first time logged in' if userDisplayName is set and previouslyLoggedInAt not set SDT-481" in new Setup {
+    "Show 'first time logged in' if previouslyLoggedInAt not set SDT-481" in new Setup {
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
         "showLastLogInStatus" -> Map(
-          "userDisplayName" -> "Bob"
+          "previouslyLoggedInAt" -> false
         )
       )).body
-      renderedHtml should include("Bob, this is the first time you have logged in")
+      renderedHtml should include("This is the first time you have logged in")
       renderedHtml should not include("you last signed in")
       renderedHtml should not include("Sign out")
     }
 
     // put all in map for showLastLoginTime
-    "Show 'you last signed in' if userDisplayName and previouslyLoggedInAt are set SDT-481" in new Setup {
-      val userDisplayName = "Bob"
+    "Show 'you last signed in' if previouslyLoggedInAt is set SDT-481" in new Setup {
       val previouslyLoggedInAt = "1st November 2016"
       val renderedHtml: String = localTemplateRenderer.parseTemplate(Html(""), Map(
         "showLastLogInStatus" -> Map(
-          "userDisplayName" -> userDisplayName,
           "previouslyLoggedInAt" -> previouslyLoggedInAt
         )
       )).body
-      renderedHtml should not include(s"$userDisplayName, this is the first time you have logged in")
-      renderedHtml should include(s"${userDisplayName}, you last signed in $previouslyLoggedInAt")
+      renderedHtml should not include(s"This is the first time you have logged in")
+      renderedHtml should include(s"You last signed in $previouslyLoggedInAt")
       renderedHtml should not include("Sign out")
     }
 


### PR DESCRIPTION
Amendments discussed with Nic Fellows & Sheldon Gold.

- Removal of the customer name to avoid discrepancies across services
- Introduction of (temporary) local styling to avoid the need for service level styling.