### PR TITLE
Tai 3053

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -696,6 +696,9 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
 
+            {{#gaCustomEvent}}
+                {{{gaCustomEvent}}}
+            {{/gaCustomEvent}}
 
             ga('send', 'pageview');
             ga('set', 'nonInteraction', true);


### PR DESCRIPTION
This is to enable services that use frontend-template-provider to send custom GA events before it is sent. An example of this would be to override title to send a custom title to GA.