### PR TITLE
Adding optimizely audience flag and unit tests

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -106,14 +106,14 @@
     {{/optimizelyProjectId}}
 
     {{#optimizely}}
-        {{#optimizelyAudience}}
+        {{#audience}}
             <script type="text/javascript">
-                var optimizelyAudience = "{{optimizelyAudience}}"
+                var audience = "{{audience}}"
             </script>
-        {{/optimizelyAudience}}
-        {{#optimizelyProjectId}}
-            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-        {{/optimizelyProjectId}}
+        {{/audience}}
+        {{#projectId}}
+            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{projectId}}}.js" type="text/javascript"></script>
+        {{/projectId}}
     {{/optimizely}}
 
     {{#assetsPath}}

--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -102,6 +102,11 @@
     {{/linkElems}}
 
     {{#optimizelyProjectId}}
+        {{#optimizelyAudience}}
+            <script type="text/javascript">
+                var optimizelyAudience = "{{optimizelyAudience}}"
+            </script>
+        {{/optimizelyAudience}}
         <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
     {{/optimizelyProjectId}}
 

--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -102,13 +102,19 @@
     {{/linkElems}}
 
     {{#optimizelyProjectId}}
+        <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
+    {{/optimizelyProjectId}}
+
+    {{#optimizely}}
         {{#optimizelyAudience}}
             <script type="text/javascript">
                 var optimizelyAudience = "{{optimizelyAudience}}"
             </script>
         {{/optimizelyAudience}}
-        <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-    {{/optimizelyProjectId}}
+        {{#optimizelyProjectId}}
+            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
+        {{/optimizelyProjectId}}
+    {{/optimizely}}
 
     {{#assetsPath}}
         <script src="{{assetsPath}}javascripts/vendor/modernizr.js" type="text/javascript"></script>

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -96,12 +96,12 @@ class HeadSpec extends UnitSpec with OneAppPerSuite {
     "contain optimizely audience variable if provided" in new CommonSetup {
       override lazy val inputMap = Map(
         "optimizely" -> Map(
-          "optimizelyAudience" -> "userGroup",
-          "optimizelyProjectId" -> "id123"
+          "audience" -> "userGroup",
+          "projectId" -> "id123"
         )
       )
 
-      outputText should include("var optimizelyAudience = \"userGroup\"")
+      outputText should include("var audience = \"userGroup\"")
       outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
     }
 
@@ -110,7 +110,7 @@ class HeadSpec extends UnitSpec with OneAppPerSuite {
         "optimizelyProjectId" -> "id123"
       )
 
-      outputText should not include("var optimizelyAudience")
+      outputText should not include("var audience")
       outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
     }
 

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -93,7 +93,28 @@ class HeadSpec extends UnitSpec with OneAppPerSuite {
       outputText should include("""<script src="cdn.optimizely.com/id123.js" type="text/javascript"></script>""")
     }
 
-    "contain hte default title no custom one is supplied" in new CommonSetup {
+    "contain optimizely audience variable if provided" in new CommonSetup {
+      override lazy val inputMap = Map(
+        "optimizelyProjectId" -> Map(
+          "optimizelyAudience" -> "userGroup",
+          "optimizelyProjectId" -> "id123"
+        )
+      )
+
+      outputText should include("var optimizelyAudience = \"userGroup\"")
+      outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
+    }
+
+    "not contain optimizely audience variable if not provided" in new CommonSetup {
+      override lazy val inputMap = Map(
+        "optimizelyProjectId" -> "id123"
+      )
+
+      outputText should not include("var optimizelyAudience")
+      outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
+    }
+
+    "contain the default title no custom one is supplied" in new CommonSetup {
       override lazy val inputMap = Map[String, Any]()
 
       outputText should include("GOV.UK - The best place to find government services and information")

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -95,7 +95,7 @@ class HeadSpec extends UnitSpec with OneAppPerSuite {
 
     "contain optimizely audience variable if provided" in new CommonSetup {
       override lazy val inputMap = Map(
-        "optimizelyProjectId" -> Map(
+        "optimizely" -> Map(
           "optimizelyAudience" -> "userGroup",
           "optimizelyProjectId" -> "id123"
         )


### PR DESCRIPTION
Adding optional flag so services can add a custom audience for optimizely. Resolves [Issue#47](https://github.com/hmrc/frontend-template-provider/issues/47)