### PR TITLE
Updated govuk template

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -584,13 +584,13 @@
                                     Mae hwn yn wasanaeth newydd{{^feedbackIdentifier}}.{{/feedbackIdentifier}}
                                     {{#feedbackIdentifier}}
                                         {{^authenticatedUser}}
-                                            &nbsp;- bydd eich
+                                            – bydd eich
                                             <a id="feedback-link" href="/contact/beta-feedback-unauthenticated?service={{feedbackIdentifier}}" data-sso="false" data-journey-click="other-global:Click:Feedback">
                                                 adborth</a>
                                             yn ein helpu i&#39;w wella.
                                         {{/authenticatedUser}}
                                         {{#authenticatedUser}}
-                                            &nbsp;- bydd eich
+                                            – bydd eich
                                             <a id="feedback-link" href="/contact/beta-feedback?service={{feedbackIdentifier}}" data-sso="false" data-journey-click="other-global:Click:Feedback">
                                                 adborth</a>
                                             yn ein helpu i&#39;w wella.
@@ -602,13 +602,13 @@
                                     This is a new service{{^feedbackIdentifier}}.{{/feedbackIdentifier}}
                                     {{#feedbackIdentifier}}
                                         {{^authenticatedUser}}
-                                            &nbsp;- your
+                                            – your
                                             <a id="feedback-link" href="/contact/beta-feedback-unauthenticated?service={{feedbackIdentifier}}" data-sso="false" data-journey-click="other-global:Click:Feedback">
                                                 feedback</a>
                                             will help us to improve it.
                                         {{/authenticatedUser}}
                                         {{#authenticatedUser}}
-                                            &nbsp;- your
+                                            – your
                                             <a id="feedback-link" href="/contact/beta-feedback?service={{feedbackIdentifier}}" data-sso="false" data-journey-click="other-global:Click:Feedback">
                                                 feedback</a>
                                             will help us to improve it.


### PR DESCRIPTION
Removed extra space created by a `&nbsp;` and replaced the hyphen with a dash.

This makes the banner consistent with the GOV.UK Service Manual guidance.