### PR TITLE
ST-261 ST-240: Add ga set event for custom dimensions 76 and 78

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -824,6 +824,9 @@
             {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
             {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
             {{#p800TaxYearSpan}}                            ga('set', 'dimension69', '{{{p800TaxYearSpan}}}');                            {{/p800TaxYearSpan}}
+            {{#taxCodeChangeDate}}                          ga('set', 'dimension76', '{{{taxCodeChangeDate}}}');                          {{/taxCodeChangeDate}}
+            {{#taxCodeChangeEdgeCase}}                      ga('set', 'dimension78', '{{{taxCodeChangeEdgeCase}}}');                      {{/taxCodeChangeEdgeCase}}
+
 
             {{#gaCustomEvent}}
                 {{{gaCustomEvent}}}


### PR DESCRIPTION
This  adds the set for the GA custom dimensions 76 and 77. See related work: https://github.com/hmrc/tai-frontend/pull/179