### PR TITLE
added meta tags to the head in the template

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -3,6 +3,7 @@
 <!--[if gt IE 8]><!--><html lang="{{^isWelsh}}en{{/isWelsh}}{{#isWelsh}}cy{{/isWelsh}}" class="no-js"><!--<![endif]-->
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    {{{ metaTags }}}
 
     <title>
         {{#pageTitle}}

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -331,5 +331,15 @@ class HeadSpec extends UnitSpec with OneAppPerSuite {
       outputText should include("""<a id="switchToEnglish" lang="en" href="english-language-url" data-journey-click="link - click:lang-select:English"><small><strong class="bold">English</strong></small></a>""")
       outputText should include("""<span class="faded-text--small"><strong class="bold">| Cymraeg</strong></span>""")
     }
+
+    "contain meta tags when supplied" in new CommonSetup {
+      val metaTag = "<meta />"
+
+      override lazy val inputMap = Map(
+        "metaTags" -> metaTag
+      )
+
+      outputText should include(metaTag)
+    }
   }
 }


### PR DESCRIPTION
Conditionally render meta tags in the head of the template if the value `metaTags` is in scope.
`metaTags` are unescaped as valid HTML will need to be rendered