### PR TITLE
TCST-476: Added headerScripts parameter to govuk-template

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -137,6 +137,10 @@
         {{^assetsPath}}
             <script src="/assets/3.11.0/javascripts/vendor/modernizr.js" type="text/javascript"></script>
         {{/assetsPath}}
+
+        {{#headerScripts}}
+            {{headerScripts}}
+        {{/headerScripts}}
     </head>
 
     <body {{#bodyClass}}class="{{bodyClass}}"{{/bodyClass}}>


### PR DESCRIPTION
Added parameter to allow HTML to be passed into the header.
As suggested in the name, the intended purpose is for them to be used for adding scripts to the header.