### PR TITLE
PLATUI-1046: Remove GA and Optimizely snippets from template-as-a-service

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -122,34 +122,13 @@
             {{{headInlineScript}}}
         {{/headInlineScript}}
 
-        {{#optimizelyProjectId}}
-            <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{optimizelyProjectId}}}.js" type="text/javascript"></script>
-        {{/optimizelyProjectId}}
-
         {{#optimizely}}
             {{#audience}}
                 <script type="text/javascript">
                     var audience = "{{audience}}"
                 </script>
             {{/audience}}
-            {{#projectId}}
-                <script src="{{#optimizelyBaseUrl}}{{{optimizelyBaseUrl}}}{{/optimizelyBaseUrl}}{{^optimizelyBaseUrl}}//cdn.optimizely.com/js/{{/optimizelyBaseUrl}}{{{projectId}}}.js" type="text/javascript"></script>
-            {{/projectId}}
         {{/optimizely}}
-
-        {{#googleTagManager}}
-            {{#gtmId}}
-                <script>
-                    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-{{gtmId}}');
-                </script>
-            {{/gtmId}}
-
-            {{^gtmId}}
-                <script>
-                    (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','GTM-NDJKHWK');
-                </script>
-            {{/gtmId}}
-        {{/googleTagManager}}
 
         {{#assetsPath}}
             <script src="{{assetsPath}}javascripts/vendor/modernizr.js" type="text/javascript"></script>
@@ -160,15 +139,6 @@
     </head>
 
     <body {{#bodyClass}}class="{{bodyClass}}"{{/bodyClass}}>
-        {{#googleTagManager}}
-            {{#gtmId}}
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-{{gtmId}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-            {{/gtmId}}
-            {{^gtmId}}
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NDJKHWK" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-            {{/gtmId}}
-        {{/googleTagManager}}
-
         <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
         <div id="skiplink-container">
@@ -313,7 +283,7 @@
                     </a>
                     {{/covidBannerLink}}
                 </div>
-        
+
                 {{#covidBannerDismissText}}
                 <a class="covid-banner__close" href="#" role="button">
                                     <span>
@@ -516,7 +486,7 @@
                                             </div>
                                         </div>
                                     {{/profileUrl}}
-                                    {{/isGovernmentGateway}}    
+                                    {{/isGovernmentGateway}}
                                     </div>
                                 </li>
 
@@ -793,83 +763,7 @@
         {{#googleAnalytics}}
             {{#trackingId}}
                 <script type="text/javascript">
-                    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                                (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-                    ga('create', '{{trackingId}}', '{{#cookieDomain}}{{cookieDomain}}{{/cookieDomain}}{{^cookieDomain}}auto{{/cookieDomain}}');
-                    ga('set', 'anonymizeIp', true);
-
-                    {{#fullPagePath}}                               ga('set', 'dimension1', '{{{fullPagePath}}}');                                {{/fullPagePath}}
-                    {{#taxType}}                                    ga('set', 'dimension2', '{{{taxType}}}');                                     {{/taxType}}
-                    {{#cardType}}                                   ga('set', 'dimension3', '{{{cardType}}}');                                    {{/cardType}}
-                    {{#userStatus}}                                 ga('set', 'dimension4', '{{{userStatus}}}');                                  {{/userStatus}}
-                    {{#experimentCohorts}}                          ga('set', 'dimension5', '{{{experimentCohorts}}}');                           {{/experimentCohorts}}
-                    {{#identityVerificationLoginOrigin}}            ga('set', 'dimension6', '{{{identityVerificationLoginOrigin}}}');             {{/identityVerificationLoginOrigin}}
-                    {{#scenarioType}}                               ga('set', 'dimension7', '{{{scenarioType}}}');                                {{/scenarioType}}
-                    {{#forecastValue}}                              ga('set', 'dimension8', '{{{forecastValue}}}');                               {{/forecastValue}}
-                    {{#qualifyingYears}}                            ga('set', 'dimension10', '{{{qualifyingYears}}}');                            {{/qualifyingYears}}
-                    {{#gaps}}                                       ga('set', 'dimension11', '{{{gaps}}}');                                       {{/gaps}}
-                    {{#payableGaps}}                                ga('set', 'dimension12', '{{{payableGaps}}}');                                {{/payableGaps}}
-                    {{#yearsToContribute}}                          ga('set', 'dimension13', '{{{yearsToContribute}}}');                          {{/yearsToContribute}}
-                    {{#contractedOut}}                              ga('set', 'dimension14', '{{{contractedOut}}}');                              {{/contractedOut}}
-                    {{#statePensionAge}}                            ga('set', 'dimension15', '{{{statePensionAge}}}');                            {{/statePensionAge}}
-                    {{#copeAmount}}                                 ga('set', 'dimension16', '{{{copeAmount}}}');                                 {{/copeAmount}}
-                    {{#startDate}}                                  ga('set', 'dimension17', '{{{startDate}}}');                                  {{/startDate}}
-                    {{#returnCount}}                                ga('set', 'dimension18', '{{{returnCount}}}');                                {{/returnCount}}
-                    {{#referenceNumber}}                            ga('set', 'dimension19', '{{{referenceNumber}}}');                            {{/referenceNumber}}
-                    {{#nispExclusionType}}                          ga('set', 'dimension20', '{{{nispExclusionType}}}');                          {{/nispExclusionType}}
-                    {{#forecastOnly}}                               ga('set', 'dimension21', '{{{forecastOnly}}}');                               {{/forecastOnly}}
-                    {{#authenticationProvider}}                     ga('set', 'dimension22', '{{{authenticationProvider}}}');                     {{/authenticationProvider}}
-                    {{#sosOrigin}}                                  ga('set', 'dimension23', '{{{sosOrigin}}}');                                  {{/sosOrigin}}
-                    {{#sosJourneyType}}                             ga('set', 'dimension24', '{{{sosJourneyType}}}');                             {{/sosJourneyType}}
-                    {{#sosConfidenceValue}}                         ga('set', 'dimension25', '{{{sosConfidenceValue}}}');                         {{/sosConfidenceValue}}
-                    {{#tamcMultiYearApplication}}                   ga('set', 'dimension26', '{{{tamcMultiYearApplication}}}');                   {{/tamcMultiYearApplication}}
-                    {{#tamcCurrentYearOnly}}                        ga('set', 'dimension27', '{{{tamcCurrentYearOnly}}}');                        {{/tamcCurrentYearOnly}}
-                    {{#tamcPreviousYearOnly}}                       ga('set', 'dimension28', '{{{tamcPreviousYearOnly}}}');                       {{/tamcPreviousYearOnly}}
-                    {{#tamcTransferorChangeInYourIncome}}           ga('set', 'dimension29', '{{{tamcTransferorChangeInYourIncome}}}');           {{/tamcTransferorChangeInYourIncome}}
-                    {{#tamcTransferorCancels}}                      ga('set', 'dimension30', '{{{tamcTransferorCancels}}}');                      {{/tamcTransferorCancels}}
-                    {{#tamcTransferorPreviousTaxYear}}              ga('set', 'dimension31', '{{{tamcTransferorPreviousTaxYear}}}');              {{/tamcTransferorPreviousTaxYear}}
-                    {{#tamcTransferorChooseStartOfYear}}            ga('set', 'dimension32', '{{{tamcTransferorChooseStartOfYear}}}');            {{/tamcTransferorChooseStartOfYear}}
-                    {{#tamcTransferorChooseEndOfYear}}              ga('set', 'dimension33', '{{{tamcTransferorChooseEndOfYear}}}');              {{/tamcTransferorChooseEndOfYear}}
-                    {{#tamcRecipientDivorcesCurrentYear}}           ga('set', 'dimension34', '{{{tamcRecipientDivorcesCurrentYear}}}');           {{/tamcRecipientDivorcesCurrentYear}}
-                    {{#tamcRecipientDivorcesPreviousYear}}          ga('set', 'dimension35', '{{{tamcRecipientDivorcesPreviousYear}}}');          {{/tamcRecipientDivorcesPreviousYear}}
-                    {{#tamcRecipientRejects}}                       ga('set', 'dimension36', '{{{tamcRecipientRejects}}}');                       {{/tamcRecipientRejects}}
-                    {{#tamcRecipientRejectsEndedRelationship}}      ga('set', 'dimension37', '{{{tamcRecipientRejectsEndedRelationship}}}');      {{/tamcRecipientRejectsEndedRelationship}}
-                    {{#authProvider}}                               ga('set', 'dimension38', '{{{authProvider}}}');                               {{/authProvider}}
-                    {{#confidenceLevel}}                            ga('set', 'dimension39', '{{{confidenceLevel}}}');                            {{/confidenceLevel}}
-                    {{#ageOnVisit}}                                 ga('set', 'dimension40', '{{{ageOnVisit}}}');                                 {{/ageOnVisit}}
-                    {{#gender}}                                     ga('set', 'dimension41', '{{{gender}}}');                                     {{/gender}}
-                    {{#valueOfPayment}}                             ga('set', 'dimension42', '{{{valueOfPayment}}}');                             {{/valueOfPayment}}
-                    {{#reconciliationStatus}}                       ga('set', 'dimension43', '{{{reconciliationStatus}}}');                       {{/reconciliationStatus}}
-                    {{#paymentStatus}}                              ga('set', 'dimension44', '{{{paymentStatus}}}');                              {{/paymentStatus}}
-                    {{#dueDateOfLiability}}                         ga('set', 'dimension45', '{{{dueDateOfLiability}}}');                         {{/dueDateOfLiability}}
-                    {{#callForDirectDebitAssistance}}               ga('set', 'dimension46', '{{{callForDirectDebitAssistance}}}');               {{/callForDirectDebitAssistance}}
-                    {{#printApplicationCompletePage}}               ga('set', 'dimension47', '{{{printApplicationCompletePage}}}');               {{/printApplicationCompletePage}}
-                    {{#clickFeedbackLinkOnApplicationCompleteSide}} ga('set', 'dimension48', '{{{clickFeedbackLinkOnApplicationCompleteSide}}}'); {{/clickFeedbackLinkOnApplicationCompleteSide}}
-                    {{#voaPersonId}}                                ga('set', 'dimension49', '{{{voaPersonId}}}');                                {{/voaPersonId}}
-                    {{#optimizelyTests}}                            ga('set', 'dimension50', '{{{optimizelyTests}}}');                            {{/optimizelyTests}}
-                    {{#optimizely8228818209}}                       ga('set', 'dimension51', '{{{optimizely8228818209}}}');                       {{/optimizely8228818209}}
-                    {{#offPayrollEndClientName}}                    ga('set', 'dimension52', '{{{offPayrollEndClientName}}}');                    {{/offPayrollEndClientName}}
-                    {{#offPayrollJobTitle}}                         ga('set', 'dimension53', '{{{offPayrollJobTitle}}}');                         {{/offPayrollJobTitle}}
-                    {{#valueOfIycdcPayment}}                        ga('set', 'dimension54', '{{{valueOfIycdcPayment}}}');                        {{/valueOfIycdcPayment}}
-                    {{#iycdcReconciliationStatus}}                  ga('set', 'dimension55', '{{{iycdcReconciliationStatus}}}');                  {{/iycdcReconciliationStatus}}
-                    {{#p800Type}}                                   ga('set', 'dimension56', '{{{p800Type}}}');                                   {{/p800Type}}
-                    {{#p800TaxYearSpan}}                            ga('set', 'dimension69', '{{{p800TaxYearSpan}}}');                            {{/p800TaxYearSpan}}
-                    {{#taxCodeChangeDate}}                          ga('set', 'dimension76', '{{{taxCodeChangeDate}}}');                          {{/taxCodeChangeDate}}
-                    {{#taxCodeChangeEdgeCase}}                      ga('set', 'dimension77', '{{{taxCodeChangeEdgeCase}}}');                      {{/taxCodeChangeEdgeCase}}
-                    {{#taiLandingPageInformation}}                  ga('set', 'dimension78', '{{{taiLandingPageInformation}}}');                  {{/taiLandingPageInformation}}
-                    {{#taiCYPlusOneEstimatedIncome}}                ga('set', 'dimension80', '{{{taiCYPlusOneEstimatedIncome}}}');                {{/taiCYPlusOneEstimatedIncome}}
-                    {{#taiCYEstimatedIncome}}                       ga('set', 'dimension81', '{{{taiCYEstimatedIncome}}}');                       {{/taiCYEstimatedIncome}}
-
-                    {{#gaCustomEvent}}
-                        {{{gaCustomEvent}}}
-                    {{/gaCustomEvent}}
-
-                    ga('send', 'pageview');
-                    ga('set', 'nonInteraction', true);
-
+                    window.ga = window.ga || function() {}
                 </script>
             {{/trackingId}}
         {{/googleAnalytics}}

--- a/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
@@ -104,65 +104,9 @@ class FooterSpec extends UnitSpec with OneAppPerSuite {
       outputText should not include("""<script type="text/javascript">var ssoUrl = """)
     }
 
-    "not show Google Analytics snippet when no googleAnalytics given SDT-475" in new CommonSetup {
+    "not show Google Analytics snippet" in new CommonSetup {
       override lazy val inputMap = Map[String, Any]()
       outputText should not include("""(window,document,'script','//www.google-analytics.com/analytics.js','ga')""")
-    }
-
-    "show Google Analytics snippet when googleAnalytics trackingId given SDT-475" in new CommonSetup {
-      override lazy val inputMap = Map(
-        "googleAnalytics" -> Map("trackingId" -> "UA-XXXX-Y")
-      )
-
-      outputText should include("""ga('create', 'UA-XXXX-Y', 'auto');""")
-    }
-
-    "do not add ga set if no gaSetParams given" in new CommonSetup {
-      override lazy val inputMap = Map[String, Any]()
-      outputText should not include("""ga('set'""")
-    }
-
-    "set the correct dimensions in ga" in new CommonSetup {
-      override lazy val inputMap = Map(
-        "googleAnalytics" -> Map(
-          "trackingId" -> "random",
-          "authProvider" -> "IDA",
-          "confidenceLevel" -> "200"
-        )
-      )
-
-      gaSetRegex.findAllIn(outputText).length shouldBe 2
-
-      outputText should include("'dimension38', 'IDA'")
-      outputText should include("'dimension39', '200'")
-    }
-
-    "not set the dimensions in ga when the data is blank" in new CommonSetup {
-      val authProvider = "IDA"
-      val confidenceLevel = "200"
-
-      override lazy val inputMap = Map(
-        "googleAnalytics" -> Map(
-          "trackingId" -> "random",
-          "authProvider" -> "IDA",
-          "confidenceLevel" -> null
-        )
-      )
-
-      gaSetRegex.findAllIn(outputText).length shouldBe 1
-
-      outputText should include("'dimension38', 'IDA'")
-    }
-
-    "support custom cookie domain for Google Analytics snippet SDT-475" in new CommonSetup {
-      override lazy val inputMap = Map(
-        "googleAnalytics" -> Map(
-          "trackingId" -> "UA-XXXX-Y",
-          "cookieDomain" -> "example.com"
-        )
-      )
-
-      outputText should include("""ga('create', 'UA-XXXX-Y', 'example.com');""")
     }
 
     "support inline script elements in the footer of the page" in new CommonSetup {
@@ -185,7 +129,7 @@ class FooterSpec extends UnitSpec with OneAppPerSuite {
 
     "should not include session timeout if set to true" in new CommonSetup {
       override lazy val inputMap = Map[String, Any]()
-      
+
       outputText should not include("""$.timeoutDialog({timeout: 900, countdown: 60, keep_alive_url: '/keepAliveUrl/', logout_url: '/logoutUrl/'});""")
     }
   }

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -61,36 +61,11 @@ class HeadSpec extends UnitSpec with GuiceOneAppPerSuite {
       bodyTagRegex.findFirstIn(outputText).get should include("""class="clazz"""")
     }
 
-    "contains no optimizely script SDT-471" in new CommonSetup {
+    "contains no optimizely script" in new CommonSetup {
       override lazy val inputMap = Map[String, Any]()
 
       outputText should not include("optimizely")
       outputText should not include("<script src=''") // should not include a script with no src
-    }
-
-    "contain no optimizely script if only baseUrl is provided SDT-471" in new CommonSetup {
-      override lazy val inputMap = Map(
-        "optimizelyBaseUrl" -> "cdn.optimizely.com"
-      )
-
-      outputText should not include("cdn.optimizely.com")
-    }
-
-    "contain optimizely script if only projectId is provided SDT-471" in new CommonSetup {
-      override lazy val inputMap = Map(
-        "optimizelyProjectId" -> "id123"
-      )
-
-      outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
-    }
-
-    "contain optimizely script if both url and projectId is provided SDT-470" in new CommonSetup {
-      override lazy val inputMap = Map(
-        "optimizelyBaseUrl" -> "cdn.optimizely.com/",
-        "optimizelyProjectId" -> "id123"
-      )
-
-      outputText should include("""<script src="cdn.optimizely.com/id123.js" type="text/javascript"></script>""")
     }
 
     "contain optimizely audience variable if provided" in new CommonSetup {
@@ -102,7 +77,6 @@ class HeadSpec extends UnitSpec with GuiceOneAppPerSuite {
       )
 
       outputText should include("var audience = \"userGroup\"")
-      outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
     }
 
     "not contain optimizely audience variable if not provided" in new CommonSetup {
@@ -111,7 +85,6 @@ class HeadSpec extends UnitSpec with GuiceOneAppPerSuite {
       )
 
       outputText should not include("var audience")
-      outputText should include("""<script src="//cdn.optimizely.com/js/id123.js" type="text/javascript"></script>""")
     }
 
     "contain the default title no custom one is supplied" in new CommonSetup {


### PR DESCRIPTION
This PR removes the hard-coded GA and Optimizely snippets from the Mustache template used by a number of live services.

This change will only affect frontend deployments using template-as-a-service in non-production environments or in service manager. A subsequent PR will be needed for hmrc/govuk-template to remove the snippets from production.

All integration with GA and Optimizely should now be done through hmrc/tracking-consent-frontend.
