### PR TITLE
PLATUI-1086: Remove old cookie banner

### DIFF
--- a/resources/govuk-template.mustache.html
+++ b/resources/govuk-template.mustache.html
@@ -83,7 +83,7 @@
                 <link rel="stylesheet" href="{{assetsPath}}stylesheets/application-ie7.min.css" />
             {{/assetsPath}}
             {{^assetsPath}}
-                <link rel="stylesheet" href="/assets/3.16.0/stylesheets/application-ie7.min.css" />
+                <link rel="stylesheet" href="/assets/3.19.0/stylesheets/application-ie7.min.css" />
             {{/assetsPath}}
         <![endif]-->
         <!--[if IE 8 ]>
@@ -91,7 +91,7 @@
                 <link rel="stylesheet" href="{{assetsPath}}stylesheets/application-ie.min.css" />
             {{/assetsPath}}
             {{^assetsPath}}
-                <link rel="stylesheet" href="/assets/3.16.0/stylesheets/application-ie.min.css" />
+                <link rel="stylesheet" href="/assets/3.19.0/stylesheets/application-ie.min.css" />
             {{/assetsPath}}
         <![endif]-->
 
@@ -100,7 +100,7 @@
                 <link rel="stylesheet" href="{{assetsPath}}stylesheets/application.min.css" />
             {{/assetsPath}}
             {{^assetsPath}}
-                <link rel="stylesheet" href="/assets/3.16.0/stylesheets/application.min.css" />
+                <link rel="stylesheet" href="/assets/3.19.0/stylesheets/application.min.css" />
             {{/assetsPath}}
         <!--<![endif]-->
 
@@ -134,7 +134,7 @@
             <script src="{{assetsPath}}javascripts/vendor/modernizr.js" type="text/javascript"></script>
         {{/assetsPath}}
         {{^assetsPath}}
-            <script src="/assets/3.16.0/javascripts/vendor/modernizr.js" type="text/javascript"></script>
+            <script src="/assets/3.19.0/javascripts/vendor/modernizr.js" type="text/javascript"></script>
         {{/assetsPath}}
     </head>
 
@@ -233,16 +233,6 @@
             </div>
         </header>
         <!--end header-->
-
-        <div id="global-cookie-message">
-            {{#isWelsh}}
-                <p>Mae GOV.UK yn defnyddio cwcis i wneud y safle&rsquo;n haws i&rsquo;w ddefnyddio. <a href="/help/cookies">Rhagor o wybodaeth am gwcis</a></p>
-            {{/isWelsh}}
-
-            {{^isWelsh}}
-                <p>GOV.UK uses cookies to make the site simpler. <a href="/help/cookies">Find out more about cookies</a></p>
-            {{/isWelsh}}
-        </div>
 
         {{#fullWidthBannerTitle}}
             <div id="full-width-banner" class="full-width-banner">
@@ -777,7 +767,7 @@
         {{/assetsPath}}
 
         {{^assetsPath}}
-            <script src="/assets/3.16.0/javascripts/application.min.js" type="text/javascript"></script>
+            <script src="/assets/3.19.0/javascripts/application.min.js" type="text/javascript"></script>
         {{/assetsPath}}
 
         {{#scriptElems}}

--- a/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/FooterSpec.scala
@@ -24,7 +24,7 @@ class FooterSpec extends UnitSpec with OneAppPerSuite {
   "Footer" should {
     "contain links to assets-frontend JS" in new CommonSetup {
       override lazy val inputMap = Map[String, Any]()
-      outputText should include ("""<script src="http://localhost:9032/assets/3.16.0/javascripts/application.min.js" type="text/javascript"></script>""")
+      outputText should include ("""<script src="http://localhost:9032/assets/3.19.0/javascripts/application.min.js" type="text/javascript"></script>""")
     }
 
     "contain links to a specified version of assets-frontend JS" in new CommonSetup {

--- a/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
+++ b/test/uk/gov/hmrc/frontendtemplateprovider/HeadSpec.scala
@@ -32,9 +32,9 @@ class HeadSpec extends UnitSpec with GuiceOneAppPerSuite {
 
     "contain links to assets-frontend CSS" in new CommonSetup {
       override lazy val inputMap = Map[String, Any]()
-      outputText should include("""<link rel="stylesheet" href="http://localhost:9032/assets/3.16.0/stylesheets/application-ie7.min.css" />""")
-      outputText should include("""<link rel="stylesheet" href="http://localhost:9032/assets/3.16.0/stylesheets/application-ie.min.css" />""")
-      outputText should include("""<link rel="stylesheet" href="http://localhost:9032/assets/3.16.0/stylesheets/application.min.css" />""")
+      outputText should include("""<link rel="stylesheet" href="http://localhost:9032/assets/3.19.0/stylesheets/application-ie7.min.css" />""")
+      outputText should include("""<link rel="stylesheet" href="http://localhost:9032/assets/3.19.0/stylesheets/application-ie.min.css" />""")
+      outputText should include("""<link rel="stylesheet" href="http://localhost:9032/assets/3.19.0/stylesheets/application.min.css" />""")
     }
 
     "contain links to a specified version of assets-frontend CSS" in new CommonSetup {


### PR DESCRIPTION
This PR removes the old cookie banner from the Mustache template used by a number of live services.

This PR is the second of three related PRs that will need to be merged. The others are:
* https://github.com/hmrc/assets-frontend/pull/1057 (merged already in v3.19.0 - removes the Javascript controlling the display logic)
* https://github.com/hmrc/govuk-template/pull/117 (updates the production version of the Mustache template and removes the CSS styles for the old cookie banner)